### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ and run the following in the top-level pauxy directory
 
     $ pip install -r requirements.txt
     $ python setup.py build_ext --inplace
+    $ python setup.py install
 
 You may also need to set your PYTHONPATH appropriately.
 


### PR DESCRIPTION
Add install line.

I'm not sure if it would also be useful to add Conda or similar instructions, and suggesting pyscf as an additional pip dependency. These instructions worked fine for me under a new Conda Python 3.8 environment on Debian Linux.